### PR TITLE
Switched from Ubuntu 24.04 back to 22.04

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:latest
+FROM ubuntu:22.04
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y update \
     && apt-get install -qq -y --no-install-recommends \


### PR DESCRIPTION
Building the docker container failed with the following error message. As a workaround, I changed the Ubuntu version fropm "latest" (currently 24.04)  to 22.04 which is still supported until 2027.

```
[4/6] RUN bash -c "pip install requests shapely":                                                                                                        
0.767 error: externally-managed-environment                                                                                                                 
0.767                                                                                                                                                       
0.767 × This environment is externally managed                                                                                                              
0.767 ╰─> To install Python packages system-wide, try apt install
0.767     python3-xyz, where xyz is the package you are trying to
0.767     install.
0.767     
0.767     If you wish to install a non-Debian-packaged Python package,
0.767     create a virtual environment using python3 -m venv path/to/venv.
0.767     Then use path/to/venv/bin/python and path/to/venv/bin/pip. Make
0.767     sure you have python3-full installed.
0.767     
0.767     If you wish to install a non-Debian packaged Python application,
0.767     it may be easiest to use pipx install xyz, which will manage a
0.767     virtual environment for you. Make sure you have pipx installed.
0.767     
0.767     See /usr/share/doc/python3.12/README.venv for more information.
0.767 
0.767 note: If you believe this is a mistake, please contact your Python installation or OS distribution provider. You can override this, at the risk of breaking your Python installation or OS, by passing --break-system-packages.
0.767 hint: See PEP 668 for the detailed specification.
```